### PR TITLE
Add schema validation and inject parsed object if valid

### DIFF
--- a/app/mq/__init__.py
+++ b/app/mq/__init__.py
@@ -17,10 +17,11 @@ def consumer(
     exchange=DEFAULT_EXCHANGE,
     exchange_type=ExchangeType.topic,
     declare_exchange=True,
+    schema=None
 ) -> Callable:
     """decorator for registering consumers"""
     return _manager.register_callback(
-        exchange, declare_exchange, queue, routing_key, exchange_type
+        exchange, declare_exchange, queue, routing_key, exchange_type, schema
     )
 
 

--- a/app/mq/core/manager.py
+++ b/app/mq/core/manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from typing import Dict, Optional, Callable, Any, Coroutine
+import pydantic
 
 from pika.exchange_type import ExchangeType
 
@@ -27,6 +28,7 @@ class RabbitMQManager:
         queue,
         routing_key,
         exchange_type=ExchangeType.topic,
+        schema: Optional[pydantic.BaseModel]=None
     ):
         def decorator(callback):
             name = f"{callback.__module__}.{callback.__name__}"
@@ -38,6 +40,7 @@ class RabbitMQManager:
                 "routing_key": routing_key,
                 "exchange_type": exchange_type,
                 "declare_exchange": declare_exchange,
+                "schema": schema
             }
 
             return callback
@@ -105,6 +108,7 @@ class RabbitMQManager:
                 routing_key=config["routing_key"],
                 exchange_type=config["exchange_type"],
                 declare_exchange=config["declare_exchange"],
+                schema=config["schema"]
             )
 
     def add_consumer(
@@ -117,6 +121,7 @@ class RabbitMQManager:
         routing_key: str,
         exchange_type: ExchangeType = ExchangeType.topic,
         prefetch_count: int = 1,
+        schema: Optional[pydantic.BaseModel] = None,
     ) -> AsyncRabbitConsumer:
         if name in self.consumers:
             raise ValueError(f"Consumer with name '{name}' already exists")
@@ -129,6 +134,7 @@ class RabbitMQManager:
             callback=callback,
             prefetch_count=prefetch_count,
             declare_exchange=declare_exchange,
+            schema=schema
         )
 
         self.consumers[name] = consumer


### PR DESCRIPTION
MQ consumers can now define schemas and have these schemas automatically validated with respect to the body of any consumed message. The parsed object based on the schema is directly provided to the consumer if validation succeeds.

```python
from pydantic import BaseModel

class Schema(BaseModel):
    # Define fields here
    field1: str
    field2: str
    ...

@consumer(queue="queue", exchange="exchange", routing_key="key", schema=Schema)
async def consumer(body, properties):
   # Can directly use body.field1, body.field2, etc. here
   pass
```